### PR TITLE
Rename ssl libs to avoid using them

### DIFF
--- a/OpenModelicaSetup.nsi
+++ b/OpenModelicaSetup.nsi
@@ -365,6 +365,15 @@ Section -post SEC0001
   # generate group and passwd files for this machine!
   Exec '"$INSTDIR\tools\msys\usr\bin\mkpasswd.exe" -l -c > $INSTDIR\tools\msys\etc\passwd'
   Exec '"$INSTDIR\tools\msys\usr\bin\mkgroup.exe" -l -c > $INSTDIR\tools\msys\etc\group'
+  # Rename libeay32.dll and ssleay32.dll as they seem to have issues on some newer Windows versions
+  # https://trac.openmodelica.org/OpenModelica/ticket/5909 https://www.openmodelica.org/forum/default-topic/2944-installation-problems
+!if ${PLATFORMVERSION} == "32"
+  Rename "$INSTDIR\tools\msys\mingw32\bin\libeay32.dll" "$INSTDIR\tools\msys\mingw32\bin\libeay32-O.dll"
+  Rename "$INSTDIR\tools\msys\mingw32\bin\ssleay32.dll" "$INSTDIR\tools\msys\mingw32\bin\ssleay32-O.dll"
+!else
+  Rename "$INSTDIR\tools\msys\mingw64\bin\libeay32.dll" "$INSTDIR\tools\msys\mingw64\bin\libeay32-O.dll"
+  Rename "$INSTDIR\tools\msys\mingw64\bin\ssleay32.dll" "$INSTDIR\tools\msys\mingw64\bin\ssleay32-O.dll"
+!endif
   # do post installation actions
   WriteRegStr SHCTX "${REGKEY}" Path $INSTDIR
   WriteUninstaller $INSTDIR\Uninstall.exe


### PR DESCRIPTION
The libs from msys seems to have some issues with newer versions of Windows