### PR TITLE
show something from makensis so Jenkins doesn't break the connection

### DIFF
--- a/BuildWindowsRelease.sh
+++ b/BuildWindowsRelease.sh
@@ -173,8 +173,8 @@ make OMTLMSimulatorStandalone
 # build the installer
 cd /c/dev/${OM_ENCRYPT}OM${PLATFORM}/OMSetup
 rm -rf 	OMLibraries.nsh
-if ! makensis //DPLATFORMVERSION="${PLATFORM::-3}" //DOMVERSION="${REVISION_SHORT}" //DPRODUCTVERSION=${PRODUCT_VERSION} OpenModelicaSetup.nsi > trace.txt 2>&1 ; then
-  cat trace.txt
+if ! makensis //DPLATFORMVERSION="${PLATFORM::-3}" //DOMVERSION="${REVISION_SHORT}" //DPRODUCTVERSION=${PRODUCT_VERSION} OpenModelicaSetup.nsi ; then
+  echo "Exit code: $?"
   exit 1
 fi
 


### PR DESCRIPTION
I suspect that Jenkins breaks the connection if nothing comes on the pipe for a while.