### PR TITLE
Fix OSG plugins version

### DIFF
--- a/OpenModelicaSetup.nsi
+++ b/OpenModelicaSetup.nsi
@@ -128,8 +128,8 @@ Section "OpenModelica Core" Section1
 !endif
   # Copy the qt plugins
   File /r /x "*.svn" "$%OMDEV%\tools\msys\mingw${PLATFORMVERSION}\share\qt5\plugins\*"
-  # Create the bin\osgPlugins-3.5.1 directory
-  SetOutPath "\\?\$INSTDIR\bin\osgPlugins-3.5.1"
+  # Create the bin\osgPlugins-3.6.5 directory
+  SetOutPath "\\?\$INSTDIR\bin\osgPlugins-3.6.5"
   File /r /x "*.svn" "$%OMDEV%\tools\msys\mingw${PLATFORMVERSION}\bin\osgPlugins-3.6.5\*"
   # Create bin\ffi directory and copy files in it
   SetOutPath "\\?\$INSTDIR\bin\ffi"


### PR DESCRIPTION
See https://github.com/OpenModelica/OpenModelica/issues/10165.

The bug was introduced in 6ab701f5344a86947a7304584ea487e0f415f861.
(No need to say that it has been broken for more than two years…)

When trying to load an STL file in OMEdit, here is the relevant part of the output with `set OSG_NOTIFY_LEVEL=DEBUG`:
```
DynamicLibrary::try to load library "osgPlugins-3.6.5/mingw_osgdb_stl.dll" 
itr='C:\Program Files\OpenModelica1.21.0-dev-64bit\bin' 
FindFileInPath() : trying C:\Program Files\OpenModelica1.21.0-dev-64bit\bin\osgPlugins-3.6.5\mingw_osgdb_stl.dll ... 
```
So OSG is looking for the shared library at the right location, that is, the `bin` folder inside the directory where OpenModelica has been installed, but it expects the plugins to have version 3.6.5 whilst OM is shipped with a subfolder `osgPlugins-3.5.1` instead. Here is where the required STL plugin actually lands:
```
C:\Program Files\OpenModelica1.21.0-dev-64bit\bin\osgPlugins-3.5.1\mingw_osgdb_stl.dll
```

When building and installing OMEdit through OMDev, there is no issue since OMDev contains the correct folder name.

@adrpo & @adeas31 Do you validate the fix?