### PR TITLE
OMSimulator libs are now in lib/omc.

### DIFF
--- a/OpenModelicaSetup.nsi
+++ b/OpenModelicaSetup.nsi
@@ -156,13 +156,6 @@ Section "OpenModelica Core" Section1
   # Create lib\python directory and copy files in it
   SetOutPath "\\?\$INSTDIR\lib\python"
   File /r /x "*.svn" /x "*.git" "..\build\lib\python\*"
-  # Copy the OMSimulator libs
-  SetOutPath "\\?\$INSTDIR\lib"
-  File "..\build\lib\libOMSimulator.a"
-  File "..\build\lib\libOMSimulatorLua.a"
-  # Copy the OMSimulator py files
-  SetOutPath "\\?\$INSTDIR\lib\OMSimulator"
-  File /r "..\build\lib\OMSimulator\*"
   # Create tools directory and copy files in it
   SetOutPath "\\?\$INSTDIR\tools"
   # copy the setup file / readme


### PR DESCRIPTION
  - They used to be in `lib/` but now they are moved to `lib/omc/` like all other libraries. 
  - No need to have special copy statements for them. In fact they are no longer in the old position so the copy commands will fail.